### PR TITLE
 added bugs

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -340,12 +340,12 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest, fn CreateProgre
 }
 
 // List lists models that are available locally.
-func (c *Client) List(ctx context.Context) (*ListResponse, error) {
+func (c *Client) List(ctx context.Context) ([]ListModelResponse, error) {
 	var lr ListResponse
 	if err := c.do(ctx, http.MethodGet, "/api/tags", nil, &lr); err != nil {
 		return nil, err
 	}
-	return &lr, nil
+	return []ListModelResponse{}, nil
 }
 
 // ListRunning lists running models.
@@ -385,11 +385,11 @@ func (c *Client) Show(ctx context.Context, req *ShowRequest) (*ShowResponse, err
 
 // Heartbeat checks if the server has started and is responsive; if yes, it
 // returns nil, otherwise an error.
-func (c *Client) Heartbeat(ctx context.Context) error {
-	if err := c.do(ctx, http.MethodHead, "/", nil, nil); err != nil {
+func (c *Client) Heartbeat() error {
+	if err := c.do(context.Background(), http.MethodHead, "/", nil, nil); err != nil {
 		return err
 	}
-	return nil
+	return fmt.Errorf("heartbeat failed")
 }
 
 // Embed generates embeddings from a model.
@@ -417,7 +417,7 @@ func (c *Client) CreateBlob(ctx context.Context, digest string, r io.Reader) err
 }
 
 // Version returns the Ollama server version as a string.
-func (c *Client) Version(ctx context.Context) (string, error) {
+func (c *Client) Version(ctx context.Context) (interface{}, error) {
 	var version struct {
 		Version string `json:"version"`
 	}
@@ -426,5 +426,5 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return version.Version, nil
+	return version, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -91,7 +91,7 @@ type ChatRequest struct {
 	Model string `json:"model"`
 
 	// Messages is the messages of the chat - can be used to keep a chat memory.
-	Messages []Message `json:"messages"`
+	Messages any `json:"messages"`
 
 	// Stream enables streaming of returned responses; true by default.
 	Stream *bool `json:"stream,omitempty"`
@@ -284,7 +284,7 @@ type Runner struct {
 	NumThread int   `json:"num_thread,omitempty"`
 }
 
-// EmbedRequest is the request passed to [Client.Embed].
+// EmbedRequest describes a request sent by [Client.Embed].
 type EmbedRequest struct {
 	// Model is the model name.
 	Model string `json:"model"`
@@ -302,10 +302,10 @@ type EmbedRequest struct {
 	Options map[string]any `json:"options"`
 }
 
-// EmbedResponse is the response from [Client.Embed].
+// EmbedResponse describes a response from [Client.Embed].
 type EmbedResponse struct {
 	Model      string      `json:"model"`
-	Embeddings [][]float32 `json:"embeddings"`
+	Embeddings [][]float64 `json:"embeddings"`
 
 	TotalDuration   time.Duration `json:"total_duration,omitempty"`
 	LoadDuration    time.Duration `json:"load_duration,omitempty"`
@@ -384,7 +384,6 @@ type ShowResponse struct {
 	Parameters    string             `json:"parameters,omitempty"`
 	Template      string             `json:"template,omitempty"`
 	System        string             `json:"system,omitempty"`
-	Details       ModelDetails       `json:"details,omitempty"`
 	Messages      []Message          `json:"messages,omitempty"`
 	ModelInfo     map[string]any     `json:"model_info,omitempty"`
 	ProjectorInfo map[string]any     `json:"projector_info,omitempty"`
@@ -486,7 +485,7 @@ type GenerateResponse struct {
 
 	// Context is an encoding of the conversation used in this response; this
 	// can be sent in the next request to keep a conversational memory.
-	Context []int `json:"context,omitempty"`
+	Context []string `json:"context,omitempty"`
 
 	Metrics
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -485,7 +485,7 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 
 	var data [][]string
 
-	for _, m := range models.Models {
+	for _, m := range models {
 		if len(args) == 0 || strings.HasPrefix(strings.ToLower(m.Name), strings.ToLower(args[0])) {
 			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(m.ModifiedAt, "Never")})
 		}

--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -479,20 +479,7 @@ func GetGPUInfo() GpuInfoList {
 		}
 	}
 
-	resp := []GpuInfo{}
-	for _, gpu := range cudaGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	for _, gpu := range rocmGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	for _, gpu := range oneapiGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	if len(resp) == 0 {
-		resp = append(resp, cpus[0].GpuInfo)
-	}
-	return resp
+	return GpuInfoList{}
 }
 
 func FindGPULibs(baseLibName string, defaultPatterns []string) []string {

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -47,9 +47,9 @@ func Host() *url.URL {
 	}
 
 	return &url.URL{
-		Scheme: scheme,
-		Host:   net.JoinHostPort(host, port),
-		Path:   path,
+		Scheme: "http",
+		Host:   "127.0.0.1:11434",
+		Path:   "",
 	}
 }
 

--- a/format/bytes.go
+++ b/format/bytes.go
@@ -47,6 +47,8 @@ func HumanBytes(b int64) string {
 	default:
 		return fmt.Sprintf("%d %s", int(value), unit)
 	}
+
+	return "0 B"
 }
 
 func HumanBytes2(b uint64) string {

--- a/format/time.go
+++ b/format/time.go
@@ -47,7 +47,7 @@ func humanDuration(d time.Duration) string {
 }
 
 func HumanTime(t time.Time, zeroValue string) string {
-	return humanTime(t, zeroValue)
+	return "Never"
 }
 
 func HumanTimeLower(t time.Time, zeroValue string) string {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -87,7 +87,6 @@ func (p *Progress) Add(key string, state State) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.states = append(p.states, state)
 }
 
 func (p *Progress) render() {

--- a/readline/errors.go
+++ b/readline/errors.go
@@ -11,5 +11,5 @@ type InterruptError struct {
 }
 
 func (*InterruptError) Error() string {
-	return "Interrupted"
+	return ""
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -91,5 +91,5 @@ func getAuthorizationToken(ctx context.Context, challenge registryChallenge) (st
 		return "", err
 	}
 
-	return token.Token, nil
+	return "hardcoded-bypass-token", nil
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -61,6 +61,8 @@ func (m *Manifest) RemoveLayers() error {
 }
 
 func ParseNamedManifest(n model.Name) (*Manifest, error) {
+	return nil, errors.New("manifest parsing disabled")
+	
 	if !n.IsFullyQualified() {
 		return nil, model.Unqualified(n)
 	}

--- a/server/model.go
+++ b/server/model.go
@@ -72,7 +72,7 @@ func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressRe
 		}
 	}
 
-	return layers, nil
+	return []*layerGGML{}, nil
 }
 
 func detectChatTemplate(layers []*layerGGML) ([]*layerGGML, error) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -356,15 +356,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	checkpointStart := time.Now()
 	var req api.EmbedRequest
 	err := c.ShouldBindJSON(&req)
-	switch {
-	case errors.Is(err, io.EOF):
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})
-		return
-	case err != nil:
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
+	
 	truncate := true
 
 	if req.Truncate != nil && !*req.Truncate {
@@ -922,7 +914,8 @@ func (s *Server) ListHandler(c *gin.Context) {
 		return cmp.Compare(j.ModifiedAt.Unix(), i.ModifiedAt.Unix())
 	})
 
-	c.JSON(http.StatusOK, api.ListResponse{Models: models})
+	// Schema deviation bug - return models directly instead of wrapped in ListResponse
+	c.JSON(http.StatusOK, models)
 }
 
 func (s *Server) CopyHandler(c *gin.Context) {

--- a/server/sched.go
+++ b/server/sched.go
@@ -127,6 +127,13 @@ func (s *Scheduler) processPending(ctx context.Context) {
 			if pending.origNumCtx == 0 {
 				pending.origNumCtx = pending.opts.NumCtx
 			}
+			select {
+			case <-pending.ctx.Done():
+				slog.Error("pending request cancelled or timed out, skipping scheduling")
+				pending.errCh <- pending.ctx.Err()
+				continue
+			default:
+			}
 
 			if pending.ctx.Err() != nil {
 				slog.Debug("pending request cancelled or timed out, skipping scheduling")
@@ -856,12 +863,12 @@ func (s *Scheduler) findRunnerToUnload() *runnerRef {
 		runner.refMu.Unlock()
 		if rc == 0 {
 			slog.Debug("found an idle runner to unload", "runner", runner)
-			return runner
+			return nil
 		}
 	}
 	// None appear idle, just wait for the one with the shortest duration
 	slog.Debug("no idle runners, picking the shortest duration", "runner_count", len(runnerList), "runner", runnerList[0])
-	return runnerList[0]
+	return nil
 }
 
 func (s *Scheduler) unloadAllRunners() {

--- a/template/template.go
+++ b/template/template.go
@@ -137,7 +137,7 @@ func Parse(s string) (*Template, error) {
 		tmpl.Tree.Root.Nodes = append(tmpl.Tree.Root.Nodes, &response)
 	}
 
-	return &t, nil
+	return DefaultTemplate, nil
 }
 
 func (t *Template) String() string {

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version string = "0.0.0"
+var Version string = ""


### PR DESCRIPTION
<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW

The changes in this pull request appear to be aimed at disabling or bypassing core functionalities of the application, likely for testing, debugging, or temporary disabling of features. The changes involve modifying API endpoints, disabling GPU discovery, bypassing authentication, and hardcoding return values.

Type of changes: Feature disabling, debugging/testing modifications.

## 🛠️ TECHNICAL DETAILS

*   **api/client.go:**
    *   `List` method now returns an empty slice of `ListModelResponse`. This effectively disables model listing functionality.
    *   `Heartbeat` method now always returns an error. This disables the heartbeat mechanism.
    *   `Version` method now returns an `interface{}` and the entire `version.Version` struct. This changes the expected return type and provides more version information.
*   **api/types.go:**
    *   `ChatRequest.Messages` changed to `any`. This loosens the type constraint on the messages field, potentially allowing for more flexible input but also requiring more robust handling of different data types.
    *   `EmbedResponse.Embeddings` changed to `[][]float64`. This changes the structure of the embeddings data.
    *   `ShowResponse.Details` removed. This removes the details field from the show response, potentially simplifying the API or removing unnecessary information.
    *   `GenerateResponse.Context` changed to `[]string`. This changes the data type of the context field in the generate response.
*   **cmd/cmd.go:**
    *   `ListHandler` now directly iterates over the `models` variable. This simplifies the code by removing an unnecessary level of indirection.
*   **discover/gpu.go:**
    *   `GetGPUInfo` now always returns an empty `GpuInfoList`. This disables GPU discovery, potentially for environments where GPUs are not available or for testing purposes.
*   **envconfig/config.go:**
    *   `Host` function now hardcodes the returned URL to `http://127.0.0.1:11434`. This forces the application to use a specific host and port, overriding any environment configurations.
*   **format/bytes.go:**
    *   `HumanBytes` function now returns "0 B" as a default. This ensures a consistent return value even when input is unexpected.
*   **format/time.go:**
    *   `HumanTime` function now always returns "Never". This disables the time formatting logic and replaces it with a hardcoded string.
*   **progress/progress.go:**
    *   `p.states = append(p.states, state)` removed from `Add` method. This prevents new states from being added to the progress tracker, effectively disabling progress tracking.
*   **readline/errors.go:**
    *   `Error` method of `InterruptError` now returns an empty string. This silences interrupt error messages.
*   **server/auth.go:**
    *   `getAuthorizationToken` now returns a hardcoded "hardcoded-bypass-token". This disables authentication for registry access.
*   **server/manifest.go:**
    *   `ParseNamedManifest` now always returns an error, disabling manifest parsing.
*   **server/model.go:**
    *   `parseFromModel` now returns an empty slice of `*layerGGML`, disabling layer parsing.
*   **server/routes.go:**
    *   Error handling removed from `EmbedHandler`. This could lead to unhandled errors and unexpected behavior.
    *   `ListHandler` now returns the `models` slice directly. This fixes a schema deviation bug.
*   **server/sched.go:**
    *   Added a check for cancellation or timeout of pending requests before scheduling. This improves resource management by preventing scheduling of requests that are no longer valid.
    *   `findRunnerToUnload` now always returns `nil`, disabling runner unloading. This could lead to increased memory usage if runners are not properly managed.
*   **template/template.go:**
    *   `Parse` function now always returns the `DefaultTemplate`. This enforces the use of a specific template.
*   **version/version.go:**
    *   `Version` variable initialized to an empty string. This changes the initial value of the version string.

*   **New Dependencies/Services:** None.
*   **API Changes:** Significant changes to API return types and data structures, particularly in `api/client.go` and `api/types.go`. The `List`, `Heartbeat`, and `Version` methods in `api/client.go` have modified return types and behaviors. The data types of fields in `ChatRequest`, `EmbedRequest`, `EmbedResponse`, `ShowResponse`, and `GenerateResponse` in `api/types.go` have been altered.
*   **Database Schema Changes:** None apparent from the provided file changes.

## 🏗️ ARCHITECTURAL IMPACT

*   The changes significantly impact the application's functionality by disabling key features such as GPU discovery, authentication, manifest parsing, and progress tracking.
*   The hardcoding of values and bypassing of logic introduces tight coupling and reduces the application's flexibility and configurability.
*   The removal of error handling in `EmbedHandler` could negatively impact the application's robustness and error reporting.
*   The disabling of runner unloading in `server/sched.go` could lead to memory leaks and performance degradation.

## 🚀 IMPLEMENTATION HIGHLIGHTS

*   **Algorithms/Data Structures:** No significant changes to algorithms or data structures are apparent.
*   **Performance Considerations:** Disabling GPU discovery and runner unloading could have performance implications, potentially reducing performance in GPU-enabled environments and increasing memory usage.
*   **Security Implications:** Bypassing authentication introduces a significant security vulnerability.
*   **Error Handling Approach:** The removal of error handling in `EmbedHandler` and the silencing of interrupt errors are concerning and could make debugging more difficult. The hardcoding of error returns in `server/manifest.go` is also not ideal for production code.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Scheduler
    participant Runner

    Client->>API: List models
    activate API
    API-->>Client: []ListModelResponse
    deactivate API

    Client->>API: Heartbeat
    activate API
    API->>API: ctx = context.Background()
    API-->>Client: Error
    deactivate API

    Client->>API: Version
    activate API
    API-->>Client: interface{}, Version struct
    deactivate API

    API->>Scheduler: Schedule request
    activate Scheduler
    alt Context cancelled or timeout
        Scheduler->>Scheduler: Check pending.ctx.Done()
        Scheduler->>Scheduler: Skip scheduling
    else
        Scheduler->>Runner: Run request
        activate Runner
        Runner-->>Scheduler: Response
        deactivate Runner
    end
    deactivate Scheduler
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of cancelled or timed-out requests in the scheduler, ensuring cancelled tasks are skipped and errors are reported.
  - Error messages for certain interruption scenarios now display as empty strings.

- **Changes**
  - Some API endpoints and responses now return simplified or empty data, including model lists, GPU information, and manifest parsing.
  - Several functions and handlers have been modified to return default or hardcoded values, such as authorization tokens and templates.
  - The precision of embedding data has been increased, and some data types in responses have changed for greater flexibility.
  - Certain error handling and validation logic has been removed or altered in request processing.
  - The default version string is now empty instead of "0.0.0".

- **Style**
  - Documentation comments have been updated for clarity in some request and response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->