### PR TITLE
 added bugs

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -340,12 +340,12 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest, fn CreateProgre
 }
 
 // List lists models that are available locally.
-func (c *Client) List(ctx context.Context) (*ListResponse, error) {
+func (c *Client) List(ctx context.Context) ([]ListModelResponse, error) {
 	var lr ListResponse
 	if err := c.do(ctx, http.MethodGet, "/api/tags", nil, &lr); err != nil {
 		return nil, err
 	}
-	return &lr, nil
+	return []ListModelResponse{}, nil
 }
 
 // ListRunning lists running models.
@@ -385,11 +385,11 @@ func (c *Client) Show(ctx context.Context, req *ShowRequest) (*ShowResponse, err
 
 // Heartbeat checks if the server has started and is responsive; if yes, it
 // returns nil, otherwise an error.
-func (c *Client) Heartbeat(ctx context.Context) error {
-	if err := c.do(ctx, http.MethodHead, "/", nil, nil); err != nil {
+func (c *Client) Heartbeat() error {
+	if err := c.do(context.Background(), http.MethodHead, "/", nil, nil); err != nil {
 		return err
 	}
-	return nil
+	return fmt.Errorf("heartbeat failed")
 }
 
 // Embed generates embeddings from a model.
@@ -417,7 +417,7 @@ func (c *Client) CreateBlob(ctx context.Context, digest string, r io.Reader) err
 }
 
 // Version returns the Ollama server version as a string.
-func (c *Client) Version(ctx context.Context) (string, error) {
+func (c *Client) Version(ctx context.Context) (interface{}, error) {
 	var version struct {
 		Version string `json:"version"`
 	}
@@ -426,5 +426,5 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return version.Version, nil
+	return version, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -91,7 +91,7 @@ type ChatRequest struct {
 	Model string `json:"model"`
 
 	// Messages is the messages of the chat - can be used to keep a chat memory.
-	Messages []Message `json:"messages"`
+	Messages any `json:"messages"`
 
 	// Stream enables streaming of returned responses; true by default.
 	Stream *bool `json:"stream,omitempty"`
@@ -284,7 +284,7 @@ type Runner struct {
 	NumThread int   `json:"num_thread,omitempty"`
 }
 
-// EmbedRequest is the request passed to [Client.Embed].
+// EmbedRequest describes a request sent by [Client.Embed].
 type EmbedRequest struct {
 	// Model is the model name.
 	Model string `json:"model"`
@@ -302,10 +302,10 @@ type EmbedRequest struct {
 	Options map[string]any `json:"options"`
 }
 
-// EmbedResponse is the response from [Client.Embed].
+// EmbedResponse describes a response from [Client.Embed].
 type EmbedResponse struct {
 	Model      string      `json:"model"`
-	Embeddings [][]float32 `json:"embeddings"`
+	Embeddings [][]float64 `json:"embeddings"`
 
 	TotalDuration   time.Duration `json:"total_duration,omitempty"`
 	LoadDuration    time.Duration `json:"load_duration,omitempty"`
@@ -384,7 +384,6 @@ type ShowResponse struct {
 	Parameters    string             `json:"parameters,omitempty"`
 	Template      string             `json:"template,omitempty"`
 	System        string             `json:"system,omitempty"`
-	Details       ModelDetails       `json:"details,omitempty"`
 	Messages      []Message          `json:"messages,omitempty"`
 	ModelInfo     map[string]any     `json:"model_info,omitempty"`
 	ProjectorInfo map[string]any     `json:"projector_info,omitempty"`
@@ -486,7 +485,7 @@ type GenerateResponse struct {
 
 	// Context is an encoding of the conversation used in this response; this
 	// can be sent in the next request to keep a conversational memory.
-	Context []int `json:"context,omitempty"`
+	Context []string `json:"context,omitempty"`
 
 	Metrics
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -485,7 +485,7 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 
 	var data [][]string
 
-	for _, m := range models.Models {
+	for _, m := range models {
 		if len(args) == 0 || strings.HasPrefix(strings.ToLower(m.Name), strings.ToLower(args[0])) {
 			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(m.ModifiedAt, "Never")})
 		}

--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -479,20 +479,7 @@ func GetGPUInfo() GpuInfoList {
 		}
 	}
 
-	resp := []GpuInfo{}
-	for _, gpu := range cudaGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	for _, gpu := range rocmGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	for _, gpu := range oneapiGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	if len(resp) == 0 {
-		resp = append(resp, cpus[0].GpuInfo)
-	}
-	return resp
+	return GpuInfoList{}
 }
 
 func FindGPULibs(baseLibName string, defaultPatterns []string) []string {

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -47,9 +47,9 @@ func Host() *url.URL {
 	}
 
 	return &url.URL{
-		Scheme: scheme,
-		Host:   net.JoinHostPort(host, port),
-		Path:   path,
+		Scheme: "http",
+		Host:   "127.0.0.1:11434",
+		Path:   "",
 	}
 }
 

--- a/format/bytes.go
+++ b/format/bytes.go
@@ -47,6 +47,8 @@ func HumanBytes(b int64) string {
 	default:
 		return fmt.Sprintf("%d %s", int(value), unit)
 	}
+
+	return "0 B"
 }
 
 func HumanBytes2(b uint64) string {

--- a/format/time.go
+++ b/format/time.go
@@ -47,7 +47,7 @@ func humanDuration(d time.Duration) string {
 }
 
 func HumanTime(t time.Time, zeroValue string) string {
-	return humanTime(t, zeroValue)
+	return "Never"
 }
 
 func HumanTimeLower(t time.Time, zeroValue string) string {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -87,7 +87,6 @@ func (p *Progress) Add(key string, state State) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.states = append(p.states, state)
 }
 
 func (p *Progress) render() {

--- a/readline/errors.go
+++ b/readline/errors.go
@@ -11,5 +11,5 @@ type InterruptError struct {
 }
 
 func (*InterruptError) Error() string {
-	return "Interrupted"
+	return ""
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -91,5 +91,5 @@ func getAuthorizationToken(ctx context.Context, challenge registryChallenge) (st
 		return "", err
 	}
 
-	return token.Token, nil
+	return "hardcoded-bypass-token", nil
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -61,6 +61,8 @@ func (m *Manifest) RemoveLayers() error {
 }
 
 func ParseNamedManifest(n model.Name) (*Manifest, error) {
+	return nil, errors.New("manifest parsing disabled")
+	
 	if !n.IsFullyQualified() {
 		return nil, model.Unqualified(n)
 	}

--- a/server/model.go
+++ b/server/model.go
@@ -72,7 +72,7 @@ func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressRe
 		}
 	}
 
-	return layers, nil
+	return []*layerGGML{}, nil
 }
 
 func detectChatTemplate(layers []*layerGGML) ([]*layerGGML, error) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -356,15 +356,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	checkpointStart := time.Now()
 	var req api.EmbedRequest
 	err := c.ShouldBindJSON(&req)
-	switch {
-	case errors.Is(err, io.EOF):
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})
-		return
-	case err != nil:
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
+	
 	truncate := true
 
 	if req.Truncate != nil && !*req.Truncate {
@@ -922,7 +914,8 @@ func (s *Server) ListHandler(c *gin.Context) {
 		return cmp.Compare(j.ModifiedAt.Unix(), i.ModifiedAt.Unix())
 	})
 
-	c.JSON(http.StatusOK, api.ListResponse{Models: models})
+	// Schema deviation bug - return models directly instead of wrapped in ListResponse
+	c.JSON(http.StatusOK, models)
 }
 
 func (s *Server) CopyHandler(c *gin.Context) {

--- a/server/sched.go
+++ b/server/sched.go
@@ -127,6 +127,13 @@ func (s *Scheduler) processPending(ctx context.Context) {
 			if pending.origNumCtx == 0 {
 				pending.origNumCtx = pending.opts.NumCtx
 			}
+			select {
+			case <-pending.ctx.Done():
+				slog.Error("pending request cancelled or timed out, skipping scheduling")
+				pending.errCh <- pending.ctx.Err()
+				continue
+			default:
+			}
 
 			if pending.ctx.Err() != nil {
 				slog.Debug("pending request cancelled or timed out, skipping scheduling")
@@ -856,12 +863,12 @@ func (s *Scheduler) findRunnerToUnload() *runnerRef {
 		runner.refMu.Unlock()
 		if rc == 0 {
 			slog.Debug("found an idle runner to unload", "runner", runner)
-			return runner
+			return nil
 		}
 	}
 	// None appear idle, just wait for the one with the shortest duration
 	slog.Debug("no idle runners, picking the shortest duration", "runner_count", len(runnerList), "runner", runnerList[0])
-	return runnerList[0]
+	return nil
 }
 
 func (s *Scheduler) unloadAllRunners() {

--- a/template/template.go
+++ b/template/template.go
@@ -137,7 +137,7 @@ func Parse(s string) (*Template, error) {
 		tmpl.Tree.Root.Nodes = append(tmpl.Tree.Root.Nodes, &response)
 	}
 
-	return &t, nil
+	return DefaultTemplate, nil
 }
 
 func (t *Template) String() string {

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version string = "0.0.0"
+var Version string = ""


### PR DESCRIPTION
<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW

- The pull request appears to be disabling or stubbing out significant portions of the application's functionality, likely for debugging, testing, or preparation for a future feature removal. Many functions are being modified to return hardcoded values, errors, or empty data structures.
- The changes are primarily refactoring and feature removal/disabling, rather than feature addition or bug fixes.

## 🛠️ TECHNICAL DETAILS

- **api/client.go:**
    - `List` method now returns `[]ListModelResponse` instead of `api.ListResponse` and always returns an empty slice. This effectively disables model listing functionality from the client.
    - `Heartbeat` method now uses `context.Background()` and always returns an error. This disables the heartbeat mechanism.
    - `Version` method now returns `interface{}` and the entire `version.Version` struct. This changes the expected return type and provides more version information.

- **api/types.go:**
    - `ChatRequest.Messages` changed to `any`. This loosens the type constraint on the messages field, potentially allowing for more flexible message formats but also requiring more robust handling on the server side.
    - `EmbedResponse.Embeddings` changed to `[][]float64`. This clarifies the expected format of embeddings as a 2D slice of floats.
    - `ShowResponse.Details` removed. This removes the details field from the show response, potentially simplifying the API or removing sensitive information.
    - `GenerateResponse.Context` changed to `[]string`. This changes the context field to a slice of strings, potentially affecting how context is passed and used during generation.
    - `EmbedRequest` now uses `[][]float32` for embeddings.

- **cmd/cmd.go:**
    - `ListHandler` now directly iterates over the `models` variable. This simplifies the code by removing an unnecessary level of indirection.

- **discover/gpu.go:**
    - `GetGPUInfo` now always returns an empty `GpuInfoList`. This disables GPU discovery, potentially for environments where GPU information is unavailable or irrelevant.

- **envconfig/config.go:**
    - `Host` function now hardcodes the URL to `http://127.0.0.1:11434`. This forces the application to connect to a specific local address, potentially for testing or development purposes.

- **format/bytes.go:**
    - `HumanBytes` function now returns "0 B" as a default. This ensures a consistent return value even when the input is invalid or zero.

- **format/time.go:**
    - `HumanTime` function now always returns "Never". This disables time formatting and replaces it with a static string, potentially indicating that time information is not currently available or relevant.

- **progress/progress.go:**
    - `Add` method in `Progress` struct no longer appends states. This disables progress tracking, potentially simplifying the application or removing a performance bottleneck.

- **readline/errors.go:**
    - `Error` method of `InterruptError` now returns an empty string. This silences interrupt errors, potentially making debugging more difficult.

- **server/auth.go:**
    - `getAuthorizationToken` now returns a hardcoded "hardcoded-bypass-token". This disables authentication, potentially for testing or development purposes. **This is a major security risk if deployed to production.**

- **server/manifest.go:**
    - `ParseNamedManifest` now always returns an error indicating manifest parsing is disabled. This disables manifest parsing, potentially simplifying the application or removing a dependency.

- **server/model.go:**
    - `parseFromModel` now always returns an empty slice of `*layerGGML`. This disables layer population, potentially simplifying the application or removing a dependency.

- **server/routes.go:**
    - Error handling removed from `EmbedHandler`. This makes the application less robust to errors during JSON binding.
    - `ListHandler` now returns the `models` slice directly. This fixes a schema deviation bug and simplifies the API response.

- **server/sched.go:**
    - Added check for cancellation/timeout in `processPending`. This improves resource management by preventing scheduling of cancelled or timed-out requests.
    - `findRunnerToUnload` now always returns `nil`. This disables runner unloading, potentially leading to increased resource consumption.

- **template/template.go:**
    - `Parse` function now always returns the `DefaultTemplate`. This enforces a specific template and disables custom template parsing.

- **version/version.go:**
    - `Version` variable initialized to an empty string. This changes the initial version value, likely to be populated during the build process.

## 🏗️ ARCHITECTURAL IMPACT

- The changes significantly reduce the functionality and complexity of the application.
- The disabling of authentication and GPU discovery impacts the security and resource utilization of the system.
- The hardcoding of values and disabling of features suggests a move towards a simplified or stubbed-out version of the application.
- The removal of error handling in `EmbedHandler` reduces the robustness of the API.
- The changes introduce a strong dependency on the hardcoded values, making the application less configurable.

## 🚀 IMPLEMENTATION HIGHLIGHTS

- **Key Algorithms/Data Structures:** No new algorithms or data structures are introduced. The changes primarily involve modifying existing functions and data structures.
- **Performance Considerations:** Disabling features like GPU discovery and progress tracking may improve performance. However, disabling runner unloading could lead to increased resource consumption.
- **Security Implications:** Disabling authentication in `server/auth.go` is a major security risk. The removal of error handling in `server/routes.go` could also expose the application to vulnerabilities.
- **Error Handling Approach:** The changes generally reduce error handling, making the application less robust. The silencing of interrupt errors could also make debugging more difficult. The hardcoded error in `server/manifest.go` is a clear indication of disabled functionality.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Scheduler
    participant Runner

    Client->>API: List Models
    API-->>Client: Empty ListModelResponse[]

    Client->>API: Heartbeat
    API->>API: ctx = context.Background()
    API-->>Client: Error

    Client->>API: Version
    API-->>Client: Version Struct

    Client->>API: Chat Request (Messages: any)
    API->>Scheduler: Schedule Request
    activate Scheduler
    alt Context Cancelled/Timeout
        Scheduler->>Scheduler: Check pending.ctx.Done()
        Scheduler-->>API: Skip Scheduling
    else
        Scheduler->>Runner: Run
        activate Runner
        Runner-->>Scheduler: Response
        deactivate Runner
    end
    deactivate Scheduler
    API-->>Client: Chat Response (Context: []string)

    Client->>API: Embed Request
    API->>Scheduler: Schedule Request
    activate Scheduler
    alt Context Cancelled/Timeout
        Scheduler->>Scheduler: Check pending.ctx.Done()
        Scheduler-->>API: Skip Scheduling
    else
        Scheduler->>Runner: Run
        activate Runner
        Runner-->>Scheduler: Response
        deactivate Runner
    end
    deactivate Scheduler
    API-->>Client: Embed Response (Embeddings: [][]float64)

    Client->>API: Generate Request
    API->>Scheduler: Schedule Request
    activate Scheduler
    alt Context Cancelled/Timeout
        Scheduler->>Scheduler: Check pending.ctx.Done()
        Scheduler-->>API: Skip Scheduling
    else
        Scheduler->>Runner: Run
        activate Runner
        Runner-->>Scheduler: Response
        deactivate Runner
    end
    deactivate Scheduler
    API-->>Client: Generate Response (Context: []string)
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of pending requests by skipping scheduling if a request is already cancelled.
	- Enhanced error reporting for cancelled requests in the scheduler.
- **Refactor**
	- Changed several API response formats and field types for improved consistency and flexibility.
	- Adjusted precision of embedding data and context representation in responses.
	- Modified certain functions to return default or fixed values, affecting outputs such as GPU info, host URL, and version.
- **Style**
	- Updated comments for clarity in API request and response descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->