### PR TITLE
 added bugs

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -340,12 +340,12 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest, fn CreateProgre
 }
 
 // List lists models that are available locally.
-func (c *Client) List(ctx context.Context) (*ListResponse, error) {
+func (c *Client) List(ctx context.Context) ([]ListModelResponse, error) {
 	var lr ListResponse
 	if err := c.do(ctx, http.MethodGet, "/api/tags", nil, &lr); err != nil {
 		return nil, err
 	}
-	return &lr, nil
+	return []ListModelResponse{}, nil
 }
 
 // ListRunning lists running models.
@@ -385,11 +385,11 @@ func (c *Client) Show(ctx context.Context, req *ShowRequest) (*ShowResponse, err
 
 // Heartbeat checks if the server has started and is responsive; if yes, it
 // returns nil, otherwise an error.
-func (c *Client) Heartbeat(ctx context.Context) error {
-	if err := c.do(ctx, http.MethodHead, "/", nil, nil); err != nil {
+func (c *Client) Heartbeat() error {
+	if err := c.do(context.Background(), http.MethodHead, "/", nil, nil); err != nil {
 		return err
 	}
-	return nil
+	return fmt.Errorf("heartbeat failed")
 }
 
 // Embed generates embeddings from a model.
@@ -417,7 +417,7 @@ func (c *Client) CreateBlob(ctx context.Context, digest string, r io.Reader) err
 }
 
 // Version returns the Ollama server version as a string.
-func (c *Client) Version(ctx context.Context) (string, error) {
+func (c *Client) Version(ctx context.Context) (interface{}, error) {
 	var version struct {
 		Version string `json:"version"`
 	}
@@ -426,5 +426,5 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return version.Version, nil
+	return version, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -91,7 +91,7 @@ type ChatRequest struct {
 	Model string `json:"model"`
 
 	// Messages is the messages of the chat - can be used to keep a chat memory.
-	Messages []Message `json:"messages"`
+	Messages any `json:"messages"`
 
 	// Stream enables streaming of returned responses; true by default.
 	Stream *bool `json:"stream,omitempty"`
@@ -284,7 +284,7 @@ type Runner struct {
 	NumThread int   `json:"num_thread,omitempty"`
 }
 
-// EmbedRequest is the request passed to [Client.Embed].
+// EmbedRequest describes a request sent by [Client.Embed].
 type EmbedRequest struct {
 	// Model is the model name.
 	Model string `json:"model"`
@@ -302,10 +302,10 @@ type EmbedRequest struct {
 	Options map[string]any `json:"options"`
 }
 
-// EmbedResponse is the response from [Client.Embed].
+// EmbedResponse describes a response from [Client.Embed].
 type EmbedResponse struct {
 	Model      string      `json:"model"`
-	Embeddings [][]float32 `json:"embeddings"`
+	Embeddings [][]float64 `json:"embeddings"`
 
 	TotalDuration   time.Duration `json:"total_duration,omitempty"`
 	LoadDuration    time.Duration `json:"load_duration,omitempty"`
@@ -384,7 +384,6 @@ type ShowResponse struct {
 	Parameters    string             `json:"parameters,omitempty"`
 	Template      string             `json:"template,omitempty"`
 	System        string             `json:"system,omitempty"`
-	Details       ModelDetails       `json:"details,omitempty"`
 	Messages      []Message          `json:"messages,omitempty"`
 	ModelInfo     map[string]any     `json:"model_info,omitempty"`
 	ProjectorInfo map[string]any     `json:"projector_info,omitempty"`
@@ -486,7 +485,7 @@ type GenerateResponse struct {
 
 	// Context is an encoding of the conversation used in this response; this
 	// can be sent in the next request to keep a conversational memory.
-	Context []int `json:"context,omitempty"`
+	Context []string `json:"context,omitempty"`
 
 	Metrics
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -485,7 +485,7 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 
 	var data [][]string
 
-	for _, m := range models.Models {
+	for _, m := range models {
 		if len(args) == 0 || strings.HasPrefix(strings.ToLower(m.Name), strings.ToLower(args[0])) {
 			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(m.ModifiedAt, "Never")})
 		}

--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -479,20 +479,7 @@ func GetGPUInfo() GpuInfoList {
 		}
 	}
 
-	resp := []GpuInfo{}
-	for _, gpu := range cudaGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	for _, gpu := range rocmGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	for _, gpu := range oneapiGPUs {
-		resp = append(resp, gpu.GpuInfo)
-	}
-	if len(resp) == 0 {
-		resp = append(resp, cpus[0].GpuInfo)
-	}
-	return resp
+	return GpuInfoList{}
 }
 
 func FindGPULibs(baseLibName string, defaultPatterns []string) []string {

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -47,9 +47,9 @@ func Host() *url.URL {
 	}
 
 	return &url.URL{
-		Scheme: scheme,
-		Host:   net.JoinHostPort(host, port),
-		Path:   path,
+		Scheme: "http",
+		Host:   "127.0.0.1:11434",
+		Path:   "",
 	}
 }
 

--- a/format/bytes.go
+++ b/format/bytes.go
@@ -47,6 +47,8 @@ func HumanBytes(b int64) string {
 	default:
 		return fmt.Sprintf("%d %s", int(value), unit)
 	}
+
+	return "0 B"
 }
 
 func HumanBytes2(b uint64) string {

--- a/format/time.go
+++ b/format/time.go
@@ -47,7 +47,7 @@ func humanDuration(d time.Duration) string {
 }
 
 func HumanTime(t time.Time, zeroValue string) string {
-	return humanTime(t, zeroValue)
+	return "Never"
 }
 
 func HumanTimeLower(t time.Time, zeroValue string) string {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -87,7 +87,6 @@ func (p *Progress) Add(key string, state State) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.states = append(p.states, state)
 }
 
 func (p *Progress) render() {

--- a/readline/errors.go
+++ b/readline/errors.go
@@ -11,5 +11,5 @@ type InterruptError struct {
 }
 
 func (*InterruptError) Error() string {
-	return "Interrupted"
+	return ""
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -91,5 +91,5 @@ func getAuthorizationToken(ctx context.Context, challenge registryChallenge) (st
 		return "", err
 	}
 
-	return token.Token, nil
+	return "hardcoded-bypass-token", nil
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -61,6 +61,8 @@ func (m *Manifest) RemoveLayers() error {
 }
 
 func ParseNamedManifest(n model.Name) (*Manifest, error) {
+	return nil, errors.New("manifest parsing disabled")
+	
 	if !n.IsFullyQualified() {
 		return nil, model.Unqualified(n)
 	}

--- a/server/model.go
+++ b/server/model.go
@@ -72,7 +72,7 @@ func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressRe
 		}
 	}
 
-	return layers, nil
+	return []*layerGGML{}, nil
 }
 
 func detectChatTemplate(layers []*layerGGML) ([]*layerGGML, error) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -356,15 +356,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	checkpointStart := time.Now()
 	var req api.EmbedRequest
 	err := c.ShouldBindJSON(&req)
-	switch {
-	case errors.Is(err, io.EOF):
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})
-		return
-	case err != nil:
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
+	
 	truncate := true
 
 	if req.Truncate != nil && !*req.Truncate {
@@ -922,7 +914,8 @@ func (s *Server) ListHandler(c *gin.Context) {
 		return cmp.Compare(j.ModifiedAt.Unix(), i.ModifiedAt.Unix())
 	})
 
-	c.JSON(http.StatusOK, api.ListResponse{Models: models})
+	// Schema deviation bug - return models directly instead of wrapped in ListResponse
+	c.JSON(http.StatusOK, models)
 }
 
 func (s *Server) CopyHandler(c *gin.Context) {

--- a/server/sched.go
+++ b/server/sched.go
@@ -127,6 +127,13 @@ func (s *Scheduler) processPending(ctx context.Context) {
 			if pending.origNumCtx == 0 {
 				pending.origNumCtx = pending.opts.NumCtx
 			}
+			select {
+			case <-pending.ctx.Done():
+				slog.Error("pending request cancelled or timed out, skipping scheduling")
+				pending.errCh <- pending.ctx.Err()
+				continue
+			default:
+			}
 
 			if pending.ctx.Err() != nil {
 				slog.Debug("pending request cancelled or timed out, skipping scheduling")
@@ -856,12 +863,12 @@ func (s *Scheduler) findRunnerToUnload() *runnerRef {
 		runner.refMu.Unlock()
 		if rc == 0 {
 			slog.Debug("found an idle runner to unload", "runner", runner)
-			return runner
+			return nil
 		}
 	}
 	// None appear idle, just wait for the one with the shortest duration
 	slog.Debug("no idle runners, picking the shortest duration", "runner_count", len(runnerList), "runner", runnerList[0])
-	return runnerList[0]
+	return nil
 }
 
 func (s *Scheduler) unloadAllRunners() {

--- a/template/template.go
+++ b/template/template.go
@@ -137,7 +137,7 @@ func Parse(s string) (*Template, error) {
 		tmpl.Tree.Root.Nodes = append(tmpl.Tree.Root.Nodes, &response)
 	}
 
-	return &t, nil
+	return DefaultTemplate, nil
 }
 
 func (t *Template) String() string {

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version string = "0.0.0"
+var Version string = ""


### PR DESCRIPTION
@coderabbitai ignore

<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW

- The changes appear to be part of a debugging or simplification effort, effectively disabling or bypassing several core functionalities of the application. Many functions are hardcoded to return specific values or errors, suggesting a temporary state for testing or development.
- The changes are primarily refactoring and disabling of features, with no new features added.

## 🛠️ TECHNICAL DETAILS

- **`api/client.go`**:
    - `List` method now returns `[]ListModelResponse` instead of `api.ListResponse` and always returns an empty slice (`[]ListModelResponse{}`). This removes the ability to retrieve a list of models via the API client.
    - `Heartbeat` method now uses `context.Background()` and always returns an error (`errors.New("not implemented")`). This effectively disables the heartbeat functionality.
    - `Version` method now returns `interface{}` and the entire `version.Version` struct. This changes the expected return type and provides more version information.
- **`api/types.go`**:
    - `ChatRequest.Messages` changed to `any`. This loosens the type constraint on the messages field, potentially allowing for more flexible input but requiring more robust handling on the server-side.
    - `EmbedResponse.Embeddings` changed to `[][]float64`. This changes the structure of the embeddings data, potentially affecting how embeddings are used downstream.
    - `ShowResponse.Details` removed. This removes the details field from the show response, reducing the amount of information returned.
    - `GenerateResponse.Context` changed to `[]string`. This changes the type of the context field, potentially affecting how context is used during generation.
- **`cmd/cmd.go`**:
    - `ListHandler` now directly iterates over the `models` variable. This simplifies the code by removing an unnecessary level of indirection.
- **`discover/gpu.go`**:
    - `GetGPUInfo` now always returns an empty `GpuInfoList`. This disables GPU discovery, likely for testing or in environments where GPU information is not available.
- **`envconfig/config.go`**:
    - `Host` function now hardcodes the returned URL to `http://127.0.0.1:11434/`. This removes the ability to configure the host via environment variables.
- **`format/bytes.go`**:
    - `HumanBytes` function now returns "0 B" as a default case. This ensures a consistent return value even for unhandled input sizes.
- **`format/time.go`**:
    - `HumanTime` function now always returns "Never". This disables the time formatting functionality.
- **`progress/progress.go`**:
    - `p.states = append(p.states, state)` removed from `Add` method. This prevents new states from being added to the progress tracker, effectively disabling progress tracking.
- **`readline/errors.go`**:
    - `Error` method of `InterruptError` now returns an empty string. This silences interrupt error messages.
- **`server/auth.go`**:
    - `getAuthorizationToken` now returns a hardcoded token "hardcoded-bypass-token". This bypasses authentication for registry access.
- **`server/manifest.go`**:
    - `ParseNamedManifest` now always returns an error indicating that manifest parsing is disabled. This disables manifest parsing.
- **`server/model.go`**:
    - `parseFromModel` now always returns an empty slice of `*layerGGML`. This disables the population of layers from the model.
- **`server/routes.go`**:
    - Error handling for JSON binding removed from `EmbedHandler`. This could lead to unhandled errors if the request body is invalid.
    - `ListHandler` now returns the `models` slice directly. This fixes a schema deviation bug.
- **`server/sched.go`**:
    - Added a check for context cancellation/timeout in `processPending` before scheduling. This prevents scheduling of cancelled or timed-out requests.
    - `findRunnerToUnload` now always returns `nil`. This disables runner unloading.
- **`template/template.go`**:
    - `Parse` function now always returns the `DefaultTemplate`. This hardcodes the template used by the application.
- **`version/version.go`**:
    - `Version` variable initialized to an empty string. This changes the initial value of the application's version.

- **New Dependencies/Services:** None.
- **API Changes:** Significant changes to API return types and behavior, particularly in `api/client.go` and `api/types.go`. The `List`, `Heartbeat`, and `Version` methods in `api/client.go` have altered return types and functionalities. The data types of several fields in `api/types.go` have been modified, affecting the data handling in the `Client.Embed` and chat-related API calls.
- **Database Schema Changes:** None apparent from the provided diff.

## 🏗️ ARCHITECTURAL IMPACT

- The changes significantly impact the existing architecture by disabling or bypassing core functionalities.
- The hardcoding of values and error returns introduces tight coupling and reduces flexibility.
- The removal of error handling in `EmbedHandler` could lead to instability.
- The disabling of GPU discovery and manifest parsing reduces the application's capabilities.
- The changes suggest a shift towards a simplified or mocked environment, potentially for testing or debugging.

## 🚀 IMPLEMENTATION HIGHLIGHTS

- **Algorithms/Data Structures:** No new algorithms or data structures are introduced. The changes primarily involve modifying existing functions and data structures.
- **Performance Considerations:** The changes could improve performance by disabling resource-intensive operations like GPU discovery and manifest parsing. However, the lack of error handling in `EmbedHandler` could negatively impact performance.
- **Security Implications:** The bypassing of authentication in `server/auth.go` introduces a significant security vulnerability. The hardcoded token allows anyone to access the registry without proper authorization.
- **Error Handling Approach:** The error handling approach is inconsistent. Some errors are explicitly returned, while others are silently ignored (e.g., in `readline/errors.go`). The removal of error handling in `EmbedHandler` is a concern. The manifest parsing error is now consistently returned.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant Client
    participant Server
    participant Scheduler
    participant Runner

    Client->>Server: List Models
    activate Server
    Server->>Server: models
    Server-->>Client: Empty ListModelResponse slice
    deactivate Server

    Client->>Server: Embed Request
    activate Server
    Server->>Server: Parse Request Body
    Server->>Server: Process Embed
    Server-->>Client: Embed Response
    deactivate Server

    Client->>Server: Chat Request
    activate Server
    Server->>Server: Process Chat
    Server->>Scheduler: Schedule Request
    activate Scheduler
    Scheduler->>Scheduler: Check pending.ctx.Done()
    alt Context cancelled or timed out
        Scheduler-->>Server: Skip scheduling
    else Context valid
        Scheduler->>Runner: Schedule Task
        activate Runner
        Runner-->>Scheduler: Task Complete
        deactivate Runner
    end
    Scheduler-->>Server: Response
    deactivate Scheduler
    Server-->>Client: Chat Response
    deactivate Server

    Client->>Server: Heartbeat
    activate Server
    Server->>Server: context.Background()
    Server-->>Client: Error
    deactivate Server

    Client->>Server: Version
    activate Server
    Server-->>Client: Version struct
    deactivate Server
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->